### PR TITLE
Fix link to ApiReference

### DIFF
--- a/Content/docs/loaders/pageloader.fsx
+++ b/Content/docs/loaders/pageloader.fsx
@@ -12,7 +12,7 @@ type Shortcut = {
 }
 
 let loader (projectRoot: string) (siteContet: SiteContents) =
-    siteContet.Add({title = "API reference"; link = "/Reference/apiRef.html"})
+    siteContet.Add({title = "API reference"; link = "/Reference/ApiRef.html"})
     siteContet.Add({title = "Home"; link = "/"; icon = "fas fa-home"})
     siteContet.Add({title = "GitHub repo"; link = "TODO: ADD_LINK"; icon = "fab fa-github"})
     siteContet.Add({title = "License"; link = "/license.html"; icon = "far fa-file-alt"})


### PR DESCRIPTION
I guess this bug was fixed in SampleWaypoint but not in WayPoint itself.
The link points to apiRef.html but the generated file is called ApiRef.html.