### PR TITLE
Use nugetDir for Paket.push

### DIFF
--- a/Content/build.fsx
+++ b/Content/build.fsx
@@ -172,7 +172,7 @@ Target.create "Push" (fun _ ->
         match getBuildParam "nuget-key" with
         | s when not (isNullOrWhiteSpace s) -> s
         | _ -> UserInput.getUserPassword "NuGet Key: "
-    Paket.push (fun p -> { p with WorkingDir = buildDir; ApiKey = key }))
+    Paket.push (fun p -> { p with WorkingDir = nugetDir; ApiKey = key }))
 
 // --------------------------------------------------------------------------------------
 // Build order


### PR DESCRIPTION
I'm just experimenting with this release strategy, but I guess buildDir is wrong, the .nupkg files are in nugetDir.