### PR TITLE
Replace "FancyApp" in documentation by "Waypoint"

### DIFF
--- a/Content/docs/loaders/globalloader.fsx
+++ b/Content/docs/loaders/globalloader.fsx
@@ -9,7 +9,7 @@ type SiteInfo = {
 }
 
 let config = {
-    title = "FancyApp"
+    title = "Waypoint"
     description = "Description of FancyApp project"
     theme_variant = Some "blue"
     numbers_in_menu = true


### PR DESCRIPTION
The documentation was generated for "FancyApp" but should be Waypoint as well I guess.

I didn't touch the description because it looks like it isn't used. Otherwise a "TODO: Add project description" would be a good thing imho.

I hope it's okay I'm opening so many very little pull requests atm.