### PR TITLE
Fix documentation build for Unix systems

### DIFF
--- a/Content/docs/loaders/contentloader.fsx
+++ b/Content/docs/loaders/contentloader.fsx
@@ -84,7 +84,7 @@ let loadFile projectRoot n =
 
     let (text, content) = getContent text
 
-    let file = relative (Path.Combine(projectRoot, "content") + "\\") n
+    let file = relative (Path.Combine(projectRoot, "content") + string Path.DirectorySeparatorChar) n
     let link = Path.ChangeExtension(file, ".html")
 
     let title = config |> List.find (fun n -> n.ToLower().StartsWith "title" ) |> fun n -> n.Split(':').[1] |> trimString


### PR DESCRIPTION
Because of one hardcoded Windows DirectorySeparator the whole documentation build failed on unix systems (like my development system).
I replaced it with a platform-specific one and now every OS is able to build the documentation again.

I tried it in my own repository and this seems to fix the error:
https://github.com/NicoVIII/GogApi.DotNet/runs/702496253