### PR TITLE
Use defined properties in Pack target

### DIFF
--- a/Content/build.fsx
+++ b/Content/build.fsx
@@ -101,7 +101,7 @@ Target.create "BuildRelease" (fun _ ->
 
 Target.create "Pack" (fun _ ->
     let properties = [
-        ("Version", latestEntry.NuGetVersion);
+        ("Version", nugetVersion);
         ("Authors", authors)
         ("PackageProjectUrl", gitUrl)
         ("PackageTags", tags)
@@ -119,7 +119,7 @@ Target.create "Pack" (fun _ ->
         { p with
             Configuration = DotNet.BuildConfiguration.Release
             OutputPath = Some nugetDir
-            MSBuildParams = { p.MSBuildParams with Properties = [("Version", nugetVersion); ("PackageReleaseNotes", packageReleaseNotes)]}
+            MSBuildParams = { p.MSBuildParams with Properties = properties}
         }
     ) "Waypoint.sln"
 )


### PR DESCRIPTION
The properties were defined but not used to pack. This fixes that.