### PR TITLE
Exclude empty changes from the changelog list

### DIFF
--- a/Content/build.fsx
+++ b/Content/build.fsx
@@ -42,10 +42,22 @@ let changelogFilename = "CHANGELOG.md"
 let changelog = Changelog.load changelogFilename
 let latestEntry = changelog.LatestEntry
 
+// Helper function to remove blank lines
+let isEmptyChange = function
+    | Changelog.Change.Added s
+    | Changelog.Change.Changed s
+    | Changelog.Change.Deprecated s
+    | Changelog.Change.Fixed s
+    | Changelog.Change.Removed s
+    | Changelog.Change.Security s
+    | Changelog.Change.Custom (_, s) ->
+        String.isNullOrWhiteSpace s.CleanedText
+
 let nugetVersion = latestEntry.NuGetVersion
 let packageReleaseNotes = sprintf "%s/blob/v%s/CHANGELOG.md" gitUrl latestEntry.NuGetVersion
 let releaseNotes =
     latestEntry.Changes
+    |> List.filter (isEmptyChange >> not)
     |> List.map (fun c -> " * " + c.ToString())
     |> String.concat "\n"
 


### PR DESCRIPTION
Because the fake parsing is returning also empty lines of changes the release notes look ugly.
This change removes those empty changes.

Here is an example how it looked before the changes:
https://github.com/NicoVIII/GogApi.DotNet/releases/tag/v2.0.0-beta.1

There is a similar issue in FAKE repository:
https://github.com/fsharp/FAKE/issues/2458