### PR TITLE
Fix index redirect for root domains with subfolder

### DIFF
--- a/Content/docs/index.html
+++ b/Content/docs/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
     <head>
         <meta charset="utf-8">
-        <meta http-equiv="refresh" content="0;url=/explanations/overview.html" />
-        <link rel="canonical" href="/explanations/overview.html" />
+        <meta http-equiv="refresh" content="0;url=./explanations/overview.html" />
+        <link rel="canonical" href="./explanations/overview.html" />
     </head>
     <body>
     </body>


### PR DESCRIPTION
I'm sorry for the PR spam..

I use GitHub generated URLs for the GitHub Pages documentation releases. Therefore the documentation is inside a subfolder of the root domain:
https://nicoviii.github.io/GogApi.DotNet/

Because of that I had problems with the index redirect because it used root and therefore I was redirected to a non existing url:
https://nicoviii.github.io/explanations/overview.html

This change should fix that.