### PR TITLE
#26: Add replacement parameters for TODO items

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ bin/
 release.cmd
 .ionide/
 build/
+/.vs/
+/Content/.vs/

--- a/.paket/Paket.Restore.targets
+++ b/.paket/Paket.Restore.targets
@@ -20,7 +20,7 @@
     <PaketBootstrapperStyle Condition="Exists('$(PaketToolsPath)paket.bootstrapper.proj')">proj</PaketBootstrapperStyle>
     <PaketExeImage>assembly</PaketExeImage>
     <PaketExeImage Condition=" '$(PaketBootstrapperStyle)' == 'proj' ">native</PaketExeImage>
-    <MonoPath Condition="'$(MonoPath)' == '' And Exists('/Library/Frameworks/Mono.framework/Commands/mono')">/Library/Frameworks/Mono.framework/Commands/mono</MonoPath>
+    <MonoPath Condition="'$(MonoPath)' == '' AND Exists('/Library/Frameworks/Mono.framework/Commands/mono')">/Library/Frameworks/Mono.framework/Commands/mono</MonoPath>
     <MonoPath Condition="'$(MonoPath)' == ''">mono</MonoPath>
 
     <!-- PaketBootStrapper  -->
@@ -28,67 +28,74 @@
     <PaketBootStrapperExePath Condition=" '$(PaketBootStrapperExePath)' == '' ">$(PaketToolsPath)paket.bootstrapper.exe</PaketBootStrapperExePath>
     <PaketBootStrapperExeDir Condition=" Exists('$(PaketBootStrapperExePath)') " >$([System.IO.Path]::GetDirectoryName("$(PaketBootStrapperExePath)"))\</PaketBootStrapperExeDir>
     
-    <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT'">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
+    <PaketBootStrapperCommand Condition=" '$(OS)' == 'Windows_NT' ">"$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
     <PaketBootStrapperCommand Condition=" '$(OS)' != 'Windows_NT' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketBootStrapperExePath)"</PaketBootStrapperCommand>
-
-    <!-- Disable automagic references for F# dotnet sdk -->
-    <!-- This will not do anything for other project types -->
-    <!-- see https://github.com/fsharp/fslang-design/blob/master/tooling/FST-1002-fsharp-in-dotnet-sdk.md -->
-    <DisableImplicitFSharpCoreReference>true</DisableImplicitFSharpCoreReference>
-    <DisableImplicitSystemValueTupleReference>true</DisableImplicitSystemValueTupleReference>
 
     <!-- Disable Paket restore under NCrunch build -->
     <PaketRestoreDisabled Condition="'$(NCrunch)' == '1'">True</PaketRestoreDisabled>
 
+    <!-- Disable test for CLI tool completely - overrideable via properties in projects or via environment variables -->
+    <PaketDisableCliTest Condition=" '$(PaketDisableCliTest)' == '' ">False</PaketDisableCliTest>
+
     <PaketIntermediateOutputPath Condition=" '$(PaketIntermediateOutputPath)' == '' ">$(BaseIntermediateOutputPath.TrimEnd('\').TrimEnd('\/'))</PaketIntermediateOutputPath>
   </PropertyGroup>
 
-  <!-- Check if paket is available as local dotnet cli tool -->
+  <!-- Resolve how paket should be called -->
+  <!-- Current priority is: local (1: repo root, 2: .paket folder) => 3: as CLI tool => as bootstrapper (4: proj Bootstrapper style, 5: BootstrapperExeDir) => 6: global path variable -->
   <Target Name="SetPaketCommand" >
-  
-    <!-- Call 'dotnet paket' and see if it returns without an error. Mute all the output. -->
-    <Exec Command="dotnet paket --version" IgnoreExitCode="true" StandardOutputImportance="low" StandardErrorImportance="low" >
+    <!-- Test if paket is available in the standard locations. If so, that takes priority. Case 1/2 - non-windows specific -->
+    <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' ">
+      <!-- no windows, try native paket as default, root => tool -->
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketRootPath)paket') ">$(PaketRootPath)paket</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketToolsPath)paket') ">$(PaketToolsPath)paket</PaketExePath>
+    </PropertyGroup>
+
+    <!-- Test if paket is available in the standard locations. If so, that takes priority. Case 2/2 - same across platforms -->
+    <PropertyGroup>
+      <!-- root => tool -->
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
+    </PropertyGroup>
+
+    <!-- If paket hasn't be found in standard locations, test for CLI tool usage. -->
+    <!-- First test: Is CLI configured to be used in "dotnet-tools.json"? - can result in a false negative; only a positive outcome is reliable. -->
+    <PropertyGroup Condition=" '$(PaketExePath)' == '' ">
+      <_DotnetToolsJson Condition="Exists('$(PaketRootPath)/.config/dotnet-tools.json')">$([System.IO.File]::ReadAllText("$(PaketRootPath)/.config/dotnet-tools.json"))</_DotnetToolsJson>
+      <_ConfigContainsPaket Condition=" '$(_DotnetToolsJson)' != ''">$(_DotnetToolsJson.Contains('"paket"'))</_ConfigContainsPaket>
+      <_ConfigContainsPaket Condition=" '$(_ConfigContainsPaket)' == ''">false</_ConfigContainsPaket>
+    </PropertyGroup>
+
+    <!-- Second test: Call 'dotnet paket' and see if it returns without an error. Mute all the output. Only run if previous test failed and the test has not been disabled. -->
+    <!-- WARNING: This method can lead to processes hanging forever, and should be used as little as possible. See https://github.com/fsprojects/Paket/issues/3705 for details. -->
+    <Exec Condition=" '$(PaketExePath)' == '' AND !$(PaketDisableCliTest) AND !$(_ConfigContainsPaket)" Command="dotnet paket --version" IgnoreExitCode="true" StandardOutputImportance="low" StandardErrorImportance="low" >
       <Output TaskParameter="ExitCode" PropertyName="LocalPaketToolExitCode" />
     </Exec>
 
-    <!-- If local paket tool is found, use that -->
-    <PropertyGroup Condition=" '$(LocalPaketToolExitCode)' == '0' ">
-      <InternalPaketCommand>dotnet paket</InternalPaketCommand>
+    <!-- If paket is installed as CLI use that. Again, only if paket haven't already been found in standard locations. -->
+    <PropertyGroup Condition=" '$(PaketExePath)' == '' AND ($(_ConfigContainsPaket) OR '$(LocalPaketToolExitCode)' == '0') ">
+      <_PaketCommand>dotnet paket</_PaketCommand>
     </PropertyGroup>
 
-    <!-- If not, then we go through our normal steps of setting the Paket command.  -->
-    <PropertyGroup Condition=" '$(LocalPaketToolExitCode)' != '0' ">
-      <!-- windows, root => tool => proj style => bootstrapper => global -->
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket.exe</PaketExePath>
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' AND Exists('$(PaketBootStrapperExeDir)') ">$(_PaketBootStrapperExeDir)paket.exe</PaketExePath>
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' == 'Windows_NT' ">paket.exe</PaketExePath>
+    <!-- If neither local files nor CLI tool can be found, final attempt is searching for boostrapper config before falling back to global path variable. -->
+    <PropertyGroup Condition=" '$(PaketExePath)' == '' AND '$(_PaketCommand)' == '' ">
+      <!-- Test for bootstrapper setup -->
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket</PaketExePath>
+      <PaketExePath Condition=" '$(PaketExePath)' == '' AND Exists('$(PaketBootStrapperExeDir)') ">$(PaketBootStrapperExeDir)paket</PaketExePath>
 
-      <!-- no windows, try native paket as default,  root => tool => proj style => mono paket => bootstrpper => global -->
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketRootPath)paket') ">$(PaketRootPath)paket</PaketExePath>
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketToolsPath)paket') ">$(PaketToolsPath)paket</PaketExePath>
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND '$(PaketBootstrapperStyle)' == 'proj' ">$(PaketToolsPath)paket</PaketExePath>
+      <!-- If all else fails, use global path approach. -->
+      <PaketExePath Condition=" '$(PaketExePath)' == ''">paket</PaketExePath>
+    </PropertyGroup>
 
-      <!-- no windows, try mono paket -->
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketRootPath)paket.exe') ">$(PaketRootPath)paket.exe</PaketExePath>
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketToolsPath)paket.exe') ">$(PaketToolsPath)paket.exe</PaketExePath>
-
-      <!-- no windows, try bootstrapper -->
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' AND Exists('$(PaketBootStrapperExeDir)') ">$(PaketBootStrapperExeDir)paket.exe</PaketExePath>
-
-      <!-- no windows, try global native paket -->
-      <PaketExePath Condition=" '$(PaketExePath)' == '' AND '$(OS)' != 'Windows_NT' ">paket</PaketExePath>
-
+    <!-- If not using CLI, setup correct execution command. -->
+    <PropertyGroup Condition=" '$(_PaketCommand)' == '' ">
       <_PaketExeExtension>$([System.IO.Path]::GetExtension("$(PaketExePath)"))</_PaketExeExtension>
-      <InternalPaketCommand Condition=" '$(InternalPaketCommand)' == '' AND '$(_PaketExeExtension)' == '.dll' ">dotnet "$(PaketExePath)"</InternalPaketCommand>
-      <InternalPaketCommand Condition=" '$(InternalPaketCommand)' == '' AND '$(OS)' != 'Windows_NT' AND '$(_PaketExeExtension)' == '.exe' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</InternalPaketCommand>
-      <InternalPaketCommand Condition=" '$(InternalPaketCommand)' == '' ">"$(PaketExePath)"</InternalPaketCommand>
-
+      <_PaketCommand Condition=" '$(_PaketCommand)' == '' AND '$(_PaketExeExtension)' == '.dll' ">dotnet "$(PaketExePath)"</_PaketCommand>
+      <_PaketCommand Condition=" '$(_PaketCommand)' == '' AND '$(OS)' != 'Windows_NT' AND '$(_PaketExeExtension)' == '.exe' ">$(MonoPath) --runtime=v4.0.30319 "$(PaketExePath)"</_PaketCommand>
+      <_PaketCommand Condition=" '$(_PaketCommand)' == '' ">"$(PaketExePath)"</_PaketCommand>
     </PropertyGroup>
 
     <!-- The way to get a property to be available outside the target is to use this task. -->
-    <CreateProperty Value="$(InternalPaketCommand)">
+    <CreateProperty Value="$(_PaketCommand)">
       <Output TaskParameter="Value" PropertyName="PaketCommand"/>
     </CreateProperty>
 

--- a/Content/.template.config/template.json
+++ b/Content/.template.config/template.json
@@ -30,7 +30,7 @@
             "defaultValue": "TODO: Add package tags"
         },
         "copyright": {
-            "description": "Copyright fort the project",
+            "description": "Copyright for the project",
             "type": "parameter",
             "replaces": "{COPYRIGHT}",
             "defaultValue": "TODO: Add copyright"

--- a/Content/.template.config/template.json
+++ b/Content/.template.config/template.json
@@ -40,6 +40,12 @@
             "type": "parameter",
             "replaces": "{GITOWNER}",
             "defaultValue": "TODO: ADD_AUTHOR"
+        },
+        "docsRootLink": {
+            "description": "Root link for deployed documentation (e.g. username.github.io/repoName)",
+            "type": "parameter",
+            "replaces": "{DOCSROOTLINK}",
+            "defaultValue": "TODO: ADD_ROOT_LINK"
         }
     }
 }

--- a/Content/.template.config/template.json
+++ b/Content/.template.config/template.json
@@ -4,10 +4,42 @@
     "classifications": [ "F#", "OSS" ],
     "name": "Waypoint",
     "tags": {
-      "language": "F#",
-      "type": "project"
+        "language": "F#",
+        "type": "project"
     },
     "identity": "Waypoint",
     "shortName": "Waypoint",
-    "sourceName": "Waypoint"
-  }
+    "sourceName": "Waypoint",
+    "symbols": {
+        "summary": {
+            "description": "A summary for your project, will be displayed for the nuget package",
+            "type": "parameter",
+            "replaces": "{SUMMARY}",
+            "defaultValue": "TODO: Add Summary"
+        },
+        "authors": {
+            "description": "Authors of the library, will be displayed for the nuget package",
+            "type": "parameter",
+            "replaces": "{AUTHORS}",
+            "defaultValue": "TODO: Add Authors"
+        },
+        "packageTags": {
+            "description": "Tags for the generated nuget package",
+            "type": "parameter",
+            "replaces": "{PACKAGETAGS}",
+            "defaultValue": "TODO: Add package tags"
+        },
+        "copyright": {
+            "description": "Copyright fort the project",
+            "type": "parameter",
+            "replaces": "{COPYRIGHT}",
+            "defaultValue": "TODO: Add copyright"
+        },
+        "gitOwner": {
+            "description": "The name of the organization or github user that owns the github repo",
+            "type": "parameter",
+            "replaces": "{GITOWNER}",
+            "defaultValue": "TODO: ADD_AUTHOR"
+        }
+    }
+}

--- a/Content/LICENSE.md
+++ b/Content/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 TODO: ADD_AUTHOR
+Copyright (c) 2020 {GITOWNER}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Content/build.fsx
+++ b/Content/build.fsx
@@ -19,12 +19,12 @@ open Fake.Api
 
 let project = "Waypoint"
 
-let summary = "TODO: Add Summary"
-let authors = "TODO: Add Authors"
-let tags = "TODO: Add package tags"
-let copyright = "TODO: Add copyright"
+let summary = "{SUMMARY}"
+let authors = "{AUTHORS}"
+let tags = "{PACKAGETAGS}"
+let copyright = "{COPYRIGHT}"
 
-let gitOwner = "TODO: ADD_AUTHOR"
+let gitOwner = "{GITOWNER}"
 let gitName = "Waypoint"
 let gitHome = "https://github.com/" + gitOwner
 let gitUrl = gitHome + "/" + gitName

--- a/Content/docs/loaders/globalloader.fsx
+++ b/Content/docs/loaders/globalloader.fsx
@@ -23,7 +23,7 @@ let config = {
       #if WATCH
         Root "//localhost:8080/"
       #else
-        Root "TODO: ADD_ROOT_LINK"
+        Root "{DOCSROOTLINK}"
       #endif
 }
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2020 TODO: ADD_AUTHOR
+Copyright (c) 2020 {GITOWNER}
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This PR adds optional parameters to pass to `dotnet new Waypoint` that fill the TODO placeholders in build.fsx and licence.md.

here's an example output:

`PS C:\Users\kevin\source\repos\kMutagene\wptest> dotnet new Waypoint --summary "test summary pls ignore" --authors "meem, soos" --packageTags "some tags m8" --copyright "me" --gitOwner "dueMcDudeson" --force`

generated build.fsx:

![image](https://user-images.githubusercontent.com/21338071/84474300-e5daaf80-ac8a-11ea-9111-bd498ff94d84.png)

This also generates a nice `--help` output:

`PS C:\Users\kevin\source\repos\kMutagene\wptest> dotnet new Waypoint --help`

![image](https://user-images.githubusercontent.com/21338071/84474727-a1034880-ac8b-11ea-8a72-dff9e072d0c8.png)
